### PR TITLE
kvm.sh symlink support

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -5,6 +5,14 @@ _kvm_has() {
     return $?
 }
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
 if _kvm_has "unsetopt"; then
     unsetopt nomatch 2>/dev/null
 fi
@@ -117,6 +125,11 @@ _kvm_unpack() {
     #Set shell commands as executable
     find "$kreFolder/bin/" -type f \
         -exec sh -c "head -c 11 {} | grep '/bin/bash' > /dev/null"  \; -print | xargs chmod 775
+
+    if [ -f "$DIR/mono" ]; then
+        echo "Linking $kreFolder/bin/mono to $DIR/mono"
+        rm -f "$kreFolder/bin/mono" && ln -s "$DIR/mono" "$kreFolder/bin/mono"
+    fi
 }
 
 # This is not currently required. Placeholder for the case when we have multiple platforms  (ie if we bundle mono)
@@ -308,6 +321,9 @@ kvm()
             if [[ -n $persistent ]]; then
                 local kreVersion=$(_kvm_package_version "$kreFullName")
                 kvm alias default "$kreVersion"
+
+                echo "Linking $DIR/current to $kreBin"
+                rm -f "$DIR/current" && ln -s "$kreBin" "$DIR/current"
             fi
         ;;
 


### PR DESCRIPTION
if mono exists at the kvm.sh folder, it will be symlinked in the unpacked kre folder. this enables kvm.sh to be tightly associated with a specific build on mono on the machine.

kvm.sh will symlink a folder named current to the most recently 'use'd kre/bin version. this enables a symlink link to current/k to pass through on the machine