### PR TITLE
Fix installed version detection in kvm.sh

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -371,6 +371,7 @@ kvm()
             
             local formattedHome=`(echo $KRE_USER_PACKAGES | sed s=$HOME=~=g)`
             for f in $(find $KRE_USER_PACKAGES/* -name "$searchGlob" -type d -prune -exec basename {} \;); do
+                [[ ! -e "$KRE_USER_PACKAGES/$f/bin" ]] && continue
                 local active=""
                 [[ $PATH == *"$KRE_USER_PACKAGES/$f/bin"* ]] && local active="  *"
                 local pkgName=$(_kvm_package_runtime "$f")

--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -69,7 +69,7 @@ _kvm_download() {
     local url="$KRE_FEED/package/$pkgName/$pkgVersion"
     local kreFile="$kreFolder/$kreFullName.nupkg"
 
-    if [ -e "$kreFolder" ]; then
+    if [ -e "$kreFolder/bin" ]; then
         echo "$kreFullName already installed."
         return 0
     fi
@@ -230,7 +230,7 @@ kvm()
                 local kreFolder="$KRE_USER_PACKAGES/$kreFullName"
                 local kreFile="$kreFolder/$kreFullName.nupkg"
 
-                if [ -e "$kreFolder" ]; then
+                if [ -e "$kreFolder/bin" ]; then
                   echo "$kreFullName already installed"
                 else
                   mkdir "$kreFolder" > /dev/null 2>&1


### PR DESCRIPTION
Fix the path for tests of installed versions by adding "/bin" to the package path. 

This resolves the issue where a KRE install that aborted before unpacking the Nuget package (because for e.g. the user ctrl-c'd during the package download) would be detected as installed and if attempt was made to install that version again, it would then fail with an error.