### PR TITLE
Don't create package dir when package doesn't exist

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -67,6 +67,7 @@ _kvm_download() {
     local pkgName=$(_kvm_package_name "$kreFullName")
     local pkgVersion=$(_kvm_package_version "$kreFullName")
     local url="$KRE_FEED/package/$pkgName/$pkgVersion"
+    local tmpKreFile="$KRE_USER_HOME/$kreFullName.nupkg"
     local kreFile="$kreFolder/$kreFullName.nupkg"
 
     if [ -e "$kreFolder" ]; then
@@ -80,14 +81,14 @@ _kvm_download() {
         echo "KVM Needs curl to proceed." >&2;
         return 1
     fi
-
-    mkdir -p "$kreFolder" > /dev/null 2>&1
-
-    local httpResult=$(curl -L -D - -u aspnetreadonly:4d8a2d9c-7b80-4162-9978-47e918c9658c "$url" -o "$kreFile" 2>/dev/null | grep "^HTTP/1.1" | head -n 1 | sed "s/HTTP.1.1 \([0-9]*\).*/\1/")
+    
+    local httpResult=$(curl -L -D - -u aspnetreadonly:4d8a2d9c-7b80-4162-9978-47e918c9658c "$url" -o "$tmpKreFile" 2>/dev/null | grep "^HTTP/1.1" | head -n 1 | sed "s/HTTP.1.1 \([0-9]*\).*/\1/")
 
     [[ $httpResult == "404" ]] && echo "$kreFullName was not found in repository $KRE_FEED" && return 1
     [[ $httpResult != "302" && $httpResult != "200" ]] && echo "HTTP Error $httpResult fetching $kreFullName from $KRE_FEED" && return 1
 
+    mkdir -p "$kreFolder" > /dev/null 2>&1
+    mv "$tmpKreFile" "$kreFile"
     _kvm_unpack $kreFile $kreFolder
     return  $? 
 }


### PR DESCRIPTION
Modified kvm_download to download to tmp file and then move to package dir on success.

Fixes #53