### PR TITLE
Update kvm.sh to support noclobber

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -332,7 +332,7 @@ kvm()
             local action="Setting"
             [[ -e "$KRE_USER_HOME/alias/$name.alias" ]] && action="Updating"
             echo "$action alias '$name' to '$kreFullName'"
-            echo "$kreFullName" > "$KRE_USER_HOME/alias/$name.alias"
+            echo "$kreFullName" >| "$KRE_USER_HOME/alias/$name.alias"
         ;;
 
         "unalias" )


### PR DESCRIPTION
Redirection of default kvm version will now overwrite the file regardless of `noclobber` option. See #111.