### PR TITLE
restore 'install <alias>' functionality and add better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@ testwork/
 .urchin*
 
 # Ignore the folder created when pushing to Home - It should be cleaned up by the task, but sometimes isn't.
-.dotnetsdk/
+.pushdnvm/
+
+# Ignore lock files
+project.lock.json
 
 [Oo]bj/
 [Bb]in/

--- a/makefile.shade
+++ b/makefile.shade
@@ -50,11 +50,11 @@ default DNVM_DEPLOY_BRANCH="${Environment.GetEnvironmentVariable("DNVM_DEPLOY_BR
     }
 
 #run-ps1-tests target='test' if='!IsLinux'
-    @{/*exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'*/}
+    exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'
 	 
 
 #run-sh-tests target='test' if='IsLinux'
-    @{/*exec program='/bin/bash' commandline="${Path.Combine(TEST_DIR, "sh", "run-tests.sh")} ${IsTeamCity?"-t ":""}-v" workingdir="${Path.Combine(TEST_DIR, "sh")}"*/}
+    exec program='/bin/bash' commandline="${Path.Combine(TEST_DIR, "sh", "run-tests.sh")} ${IsTeamCity?"-t ":""}-v" workingdir="${Path.Combine(TEST_DIR, "sh")}"
 
 #push-dnvm target='deploy' if='DEPLOY_DNVM == "1" && !String.IsNullOrEmpty(DNVM_DEPLOY_REPO) && !String.IsNullOrEmpty(DNVM_DEPLOY_BRANCH)'
 	push-dnvm repo="${DNVM_DEPLOY_REPO}" branch="${DNVM_DEPLOY_BRANCH}" files="${Path.Combine(TARGET_DIR, "dnvm.cmd")};${Path.Combine(TARGET_DIR, "dnvm.ps1")};${Path.Combine(TARGET_DIR, "dnvm.sh")}" baseMessage=":arrow_up: dnvm.ps1, dnvm.cmd, dnvm.sh"

--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -100,6 +100,9 @@ $ExitCodes = @{
     "AliasDoesNotExist"         = 1001
     "UnknownCommand"            = 1002
     "InvalidArguments"          = 1003
+    "OtherError"                = 1004
+    "NoSuchPackage"             = 1005
+    "NoRuntimesOnFeed"          = 1006
 }
 
 $ColorScheme = $DnvmColors
@@ -401,7 +404,12 @@ function Find-Latest {
     $wc = New-Object System.Net.WebClient
     Apply-Proxy $wc -Proxy:$Proxy
     _WriteDebug "Downloading $url ..."
-    [xml]$xml = $wc.DownloadString($url)
+    try {
+        [xml]$xml = $wc.DownloadString($url)
+    } catch {
+        $Script:ExitCode = $ExitCodes.NoRuntimesOnFeed
+        throw "Unable to find any runtime packages on the feed!"
+    }
 
     $version = Select-Xml "//d:Version" -Namespace @{d='http://schemas.microsoft.com/ado/2007/08/dataservices'} $xml
 
@@ -449,7 +457,12 @@ function Download-Package(
     $wc = New-Object System.Net.WebClient
     Apply-Proxy $wc -Proxy:$Proxy
     _WriteDebug "Downloading $url ..."
-    $wc.DownloadFile($url, $DestinationFile)
+    try {
+        $wc.DownloadFile($url, $DestinationFile)
+    } catch {
+        $Script:ExitCode = $ExitCodes.NoSuchPackage
+        throw "Could not find $runtimeFullName.$Version on feed: $Feed"
+    }
 }
 
 function Unpack-Package([string]$DownloadFile, [string]$UnpackFolder) {
@@ -852,9 +865,10 @@ function dnvm-upgrade {
 <#
 .SYNOPSIS
     Installs a version of the runtime
-.PARAMETER VersionOrNuPkg
-    The version to install from the current channel, the path to a '.nupkg' file to install, or 'latest' to
-    install the latest available version from the current channel.
+.PARAMETER VersionNuPkgOrAlias
+    The version to install from the current channel, the path to a '.nupkg' file to install, 'latest' to
+    install the latest available version from the current channel, or an alias value to install an alternate
+    runtime or architecture flavor of the specified alias.
 .PARAMETER Architecture
     The processor architecture of the runtime to install (default: x86)
 .PARAMETER Runtime
@@ -876,7 +890,7 @@ function dnvm-upgrade {
 function dnvm-install {
     param(
         [Parameter(Mandatory=$false, Position=0)]
-        [string]$VersionOrNuPkg,
+        [string]$VersionNuPkgOrAlias,
 
         [Alias("arch")]
         [ValidateSet("", "x86","x64")]
@@ -905,28 +919,28 @@ function dnvm-install {
         [Parameter(Mandatory=$false)]
         [switch]$Ngen)
 
-    if(!$VersionOrNuPkg) {
+    if(!$VersionNuPkgOrAlias) {
         _WriteOut "A version, nupkg path, or the string 'latest' must be provided."
         dnvm-help install
         $Script:ExitCode = $ExitCodes.InvalidArguments
         return
     }
 
-    if ($VersionOrNuPkg -eq "latest") {
-        $VersionOrNuPkg = Find-Latest $Runtime $Architecture
+    if ($VersionNuPkgOrAlias -eq "latest") {
+        $VersionNuPkgOrAlias = Find-Latest $Runtime $Architecture
     }
 
-    $IsNuPkg = $VersionOrNuPkg.EndsWith(".nupkg")
+    $IsNuPkg = $VersionNuPkgOrAlias.EndsWith(".nupkg")
 
     if ($IsNuPkg) {
-        if(!(Test-Path $VersionOrNuPkg)) {
-            throw "Unable to locate package file: '$VersionOrNuPkg'"
+        if(!(Test-Path $VersionNuPkgOrAlias)) {
+            throw "Unable to locate package file: '$VersionNuPkgOrAlias'"
         }
-        $runtimeFullName = [System.IO.Path]::GetFileNameWithoutExtension($VersionOrNuPkg)
+        $runtimeFullName = [System.IO.Path]::GetFileNameWithoutExtension($VersionNuPkgOrAlias)
         $Architecture = Get-PackageArch $runtimeFullName
         $Runtime = Get-PackageRuntime $runtimeFullName
     } else {
-        $runtimeFullName = Get-RuntimeName $VersionOrNuPkg -Architecture:$Architecture -Runtime:$Runtime
+        $runtimeFullName = Get-RuntimeName $VersionNuPkgOrAlias -Architecture:$Architecture -Runtime:$Runtime
     }
 
     $PackageVersion = Get-PackageVersion $runtimeFullName
@@ -960,12 +974,12 @@ function dnvm-install {
         New-Item -Type Directory $UnpackFolder | Out-Null
 
         if($IsNuPkg) {
-            _WriteDebug "Copying local nupkg $VersionOrNuPkg to $DownloadFile"
-            Copy-Item $VersionOrNuPkg $DownloadFile
+            _WriteDebug "Copying local nupkg $VersionNuPkgOrAlias to $DownloadFile"
+            Copy-Item $VersionNuPkgOrAlias $DownloadFile
         } else {
             # Download the package
-            _WriteDebug "Downloading version $VersionOrNuPkg to $DownloadFile"
-            Download-Package $VersionOrNuPkg $Architecture $Runtime $DownloadFile -Proxy:$Proxy
+            _WriteDebug "Downloading version $VersionNuPkgOrAlias to $DownloadFile"
+            Download-Package $PackageVersion $Architecture $Runtime $DownloadFile -Proxy:$Proxy
         }
 
         Unpack-Package $DownloadFile $UnpackFolder
@@ -1193,6 +1207,11 @@ if($UnencodedHomes -contains $OldUserHome) {
     }
 }
 
+# Check for old KRE_HOME variable
+if(Test-Path env:\KRE_HOME) {
+    _WriteOut -ForegroundColor Yellow "WARNING: Found a KRE_HOME environment variable. This variable has been deprecated and should be removed, or it may interfere with DNVM and the .NET Execution environment"
+}
+
 # Read arguments
 
 $cmd = $args[0]
@@ -1223,15 +1242,20 @@ if(!$cmd) {
     $Script:ExitCode = $ExitCodes.InvalidArguments
 }
 
-# Check for the command
-if(Get-Command -Name "$CommandPrefix$cmd" -ErrorAction SilentlyContinue) {
-    _WriteDebug "& dnvm-$cmd $cmdargs"
-    & "dnvm-$cmd" @cmdargs
-}
-else {
-    _WriteOut "Unknown command: '$cmd'"
-    dnvm-help
-    $Script:ExitCode = $ExitCodes.UnknownCommand
+# Check for the command and run it
+try {
+    if(Get-Command -Name "$CommandPrefix$cmd" -ErrorAction SilentlyContinue) {
+        _WriteDebug "& dnvm-$cmd $cmdargs"
+        & "dnvm-$cmd" @cmdargs
+    }
+    else {
+        _WriteOut "Unknown command: '$cmd'"
+        dnvm-help
+        $Script:ExitCode = $ExitCodes.UnknownCommand
+    }
+} catch {
+    Write-Error $_
+    if(!$Script:ExitCode) { $Script:ExitCode = $ExitCodes.OtherError }
 }
 
 _WriteDebug "=== End $CommandName (Exit Code $Script:ExitCode) ==="

--- a/test/apps/TestApp/Program.cs
+++ b/test/apps/TestApp/Program.cs
@@ -1,17 +1,10 @@
 using System;
 using System.Diagnostics;
-using Microsoft.Framework.Runtime;
-using Microsoft.Framework.Runtime.Common.CommandLine;
 
 namespace TestApp {
     public class Program {
-        private readonly IApplicationEnvironment _env;
-        public Program(IApplicationEnvironment env) {
-            _env = env;
-        }
-
         public int Main(string[] args) {
-            AnsiConsole.Output.WriteLine("Runtime is sane!");
+            Console.WriteLine("Runtime is sane!");
             return 0;
         } 
     }

--- a/test/apps/TestApp/project.json
+++ b/test/apps/TestApp/project.json
@@ -2,8 +2,6 @@
     "version": "0.0.1-*",
     "description": "Quick app to exercise a few .NET things",
     "dependencies": {
-        "Microsoft.Framework.Runtime.Interfaces": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Framework.CommandLineUtils": { "version": "1.0.0-*", "type": "build" }
     },
     "commands": {
         "run": "run"
@@ -12,6 +10,7 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
+                "System.Runtime": "4.0.0-*",
                 "System.Console": "4.0.0-*",
                 "System.Collections": "4.0.10-*",
                 "System.Diagnostics.Process": "4.0.0-*",

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -35,10 +35,10 @@ if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $PSScriptRoot "../app
 # Configure the Runtimes we're going to use in testing. The actual runtime doesn't matter since we're only testing
 # that dnvm can find it, download it and unpack it successfully. We do run an app in the runtime to do that sanity
 # test, but all we care about in these tests is that the app executes.
-$env:DNX_FEED = "https://www.myget.org/F/aspnetrelease/api/v2"
-$TestRuntimeVersion = "1.0.0-beta4-???"
-$specificNupkgUrl = "$($env:DNX_FEED)/package/kre-coreclr-win-x64/$TestRuntimeVersion"
-$specificNupkgHash = "E334075CD028DA2FB1BC801A2EA021AB2CE27D4E880B414817BC612C82CABE93"
+$env:DNX_FEED = "https://www.myget.org/F/aspnetvnext/api/v2"
+$TestRuntimeVersion = "1.0.0-beta4-11234"
+$specificNupkgUrl = "$($env:DNX_FEED)/package/dnx-coreclr-win-x64/$TestRuntimeVersion"
+$specificNupkgHash = "78B2E9275A667CD7B5238B5231D071070DEA609E70D62B17E539B3C310802B6B"
 $specificNupkgName = "dnx-coreclr-win-x64.$TestRuntimeVersion.nupkg"
 $specificNuPkgFxName = "Asp.Net,Version=v5.0"
 

--- a/test/ps1/tests/Install.Tests.ps1
+++ b/test/ps1/tests/Install.Tests.ps1
@@ -103,6 +103,19 @@ Describe "install" -Tag "install" {
         }
     }
 
+    Context "When installing an alias" {
+        __dnvmtest_run install $TestRuntimeVersion -Alias "test_install_alias" | Out-Null
+        $runtimeName = GetRuntimeName "CoreCLR" "x86"
+        $runtimePath = "$UserPath\runtimes\$runtimeName"
+        if(Test-Path $runtimePath) { del -rec -for $runtimePath }
+        $runtimePath | Should Not Exist
+        
+        It "downloads the same version but with the specified runtime" {
+            __dnvmtest_run install "test_install_alias" -r coreclr | Out-Null
+            $runtimePath | Should Exist
+        }
+    }
+
     Context "When installing latest" {
         $previous = @(dir "$UserPath\runtimes" | select -ExpandProperty Name)
         It "downloads a runtime" {


### PR DESCRIPTION
We should now stop on the first error (apparently the outer try...catch does that? I barely know anything about PoSH error handling :)). Also, I trap a few well-known error conditions

Also restored `dnvm install <alias>` as it turned out to be a simple fix.

/cc @NTaylorMullen @glennc @davidfowl