### PR TITLE
Regression causing file not found error when installing coreclr dnx

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -1004,6 +1004,7 @@ function dnvm-install {
 
     if(Test-Path $RuntimeFolder) {
         _WriteOut "'$runtimeFullName' is already installed."
+        dnvm-use $PackageVersion -Architecture:$Architecture -Runtime:$Runtime -Persistent:$Persistent
     }
     else {
         $Architecture = GetArch $Architecture
@@ -1038,6 +1039,8 @@ function dnvm-install {
         _WriteDebug "Cleaning temporary directory $UnpackFolder"
         Remove-Item $UnpackFolder -Force | Out-Null
 
+        dnvm-use $PackageVersion -Architecture:$Architecture -Runtime:$Runtime -Persistent:$Persistent
+
         if ($Runtime -eq "clr") {
             if (-not $NoNative) {
                 if ((Is-Elevated) -or $Ngen) {
@@ -1070,8 +1073,6 @@ function dnvm-install {
             _WriteOut "Unexpected platform: $Runtime. No optimization would be performed on the package installed."
         }
     }
-
-    dnvm-use $PackageVersion -Architecture:$Architecture -Runtime:$Runtime -Persistent:$Persistent
 
     if($Alias) {
         _WriteDebug "Aliasing installed runtime to '$Alias'"


### PR DESCRIPTION
This is a regression introduced by https://github.com/aspnet/dnvm/commit/828b00804650a8b77bf324c2f24ca4270b09ef7f.

On install of coreclr xre previously the dnvm use happened before invoking cross gen. With this change I moved this to a common place so that dnvm-use is called irrespective if the dnx already exists or not.

@pranavkm @anurse @muratg 