### PR TITLE
Fix #175 (dnvm use alias doesn't work when alias points to coreclr)

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -261,11 +261,11 @@ function GetArch($Architecture, $FallBackArch = $DefaultArchitecture) {
     }
 }
 
-function GetRuntime($Runtime) {
+function GetRuntime($Runtime, $FallBackRuntime = $DefaultRuntime) {
     if(![String]::IsNullOrWhiteSpace($Runtime)) {
         $Runtime
     } else {
-        $DefaultRuntime
+        $FallBackRuntime
     }
 }
 
@@ -342,7 +342,7 @@ function Get-RuntimeName(
         $BaseName = Get-Content $aliasPath
 
         $Architecture = GetArch $Architecture (Get-PackageArch $BaseName)
-        $Runtime = GetRuntime $Runtime (Get-PackageArch $BaseName)
+        $Runtime = GetRuntime $Runtime (Get-PackageRuntime $BaseName)
         $Version = Get-PackageVersion $BaseName
     }
     


### PR DESCRIPTION
Fix #175 
- GetRuntime extended with a fallback
- GetRuntimeName wrong Get-PackageXXX call for $Runtime corrected