### PR TITLE
Fixed Get-RuntimeName function if version is passed as alias

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -341,8 +341,8 @@ function Get-RuntimeName(
     if(Test-Path $aliasPath) {
         $BaseName = Get-Content $aliasPath
 
-        $Architecture = GetArch $Architecture (Get-PackageArch $BaseName)
-        $Runtime = GetRuntime $Runtime (Get-PackageArch $BaseName)
+        $Architecture = Get-PackageArch $BaseName
+        $Runtime = Get-PackageRuntime $BaseName
         $Version = Get-PackageVersion $BaseName
     }
     


### PR DESCRIPTION
This is fixes #260