### PR TITLE
More PSv2.0 work

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -85,8 +85,9 @@ Set-Variable -Option Constant "DefaultUserDirectoryName" ".dnx"
 Set-Variable -Option Constant "OldUserDirectoryNames" @(".kre", ".k")
 Set-Variable -Option Constant "RuntimePackageName" "dnx"
 Set-Variable -Option Constant "DefaultFeed" "https://www.nuget.org/api/v2"
-Set-Variable -Option Constant "DefaultUnstableFeed" "https://www.myget.org/F/aspnetrelease/api/v2"
+Set-Variable -Option Constant "DefaultUnstableFeed" "https://www.myget.org/F/aspnetvnext/api/v2"
 Set-Variable -Option Constant "CrossGenCommand" "dnx-crossgen"
+Set-Variable -Option Constant "OldCrossGenCommand" "k-crossgen"
 Set-Variable -Option Constant "CommandPrefix" "dnvm-"
 Set-Variable -Option Constant "DefaultArchitecture" "x86"
 Set-Variable -Option Constant "DefaultRuntime" "clr"
@@ -896,31 +897,26 @@ function dnvm-list {
 function dnvm-alias {
     param(
         [Alias("d")]
-        [Parameter(ParameterSetName="Delete",Mandatory=$true)]
         [switch]$Delete,
 
-        [Parameter(ParameterSetName="Read",Mandatory=$false,Position=0)]
-        [Parameter(ParameterSetName="Write",Mandatory=$true,Position=0)]
-        [Parameter(ParameterSetName="Delete",Mandatory=$true,Position=0)]
         [string]$Name,
-        
-        [Parameter(ParameterSetName="Write",Mandatory=$true,Position=1)]
+
         [string]$Version,
 
         [Alias("arch")]
         [ValidateSet("", "x86","x64")]
-        [Parameter(ParameterSetName="Write", Mandatory=$false)]
         [string]$Architecture = "",
 
         [Alias("r")]
         [ValidateSet("", "clr","coreclr")]
-        [Parameter(ParameterSetName="Write")]
         [string]$Runtime = "")
 
-    switch($PSCmdlet.ParameterSetName) {
-        "Read" { Read-Alias $Name }
-        "Write" { Write-Alias $Name $Version -Architecture $Architecture -Runtime $Runtime }
-        "Delete" { Delete-Alias $Name }
+    if($Version) {
+        Write-Alias $Name $Version -Architecture $Architecture -Runtime $Runtime
+    } elseif ($Delete) {
+        Delete-Alias $Name
+    } else {
+        Read-Alias $Name
     }
 }
 
@@ -1124,7 +1120,8 @@ function dnvm-install {
     else {
         $Architecture = GetArch $Architecture
         $Runtime = GetRuntime $Runtime
-        $UnpackFolder = Join-Path $RuntimesDir "temp"
+        $TempFolder = Join-Path $RuntimesDir "temp" 
+        $UnpackFolder = Join-Path $TempFolder $runtimeFullName
         $DownloadFile = Join-Path $UnpackFolder "$runtimeFullName.nupkg"
 
         if(Test-Path $UnpackFolder) {
@@ -1155,7 +1152,19 @@ function dnvm-install {
         else {
             _WriteOut "Installing to $RuntimeFolder"
             _WriteDebug "Moving package contents to $RuntimeFolder"
-            Move-Item $UnpackFolder $RuntimeFolder
+            try {
+                Move-Item $UnpackFolder $RuntimeFolder
+            } catch {
+                if(Test-Path $RuntimeFolder) {
+                    #Attempt to cleanup the runtime folder if it is there after a fail.
+                    Remove-Item $RuntimeFolder -Recurse -Force
+                    throw
+                }
+            }
+            #If there is nothing left in the temp folder remove it. There could be other installs happening at the same time as this.
+            if(-Not(Test-Path $(Join-Path $TempFolder "*"))) {
+                Remove-Item $TempFolder -Recurse
+            }
         }
 
         dnvm-use $PackageVersion -Architecture:$Architecture -Runtime:$Runtime -Persistent:$Persistent
@@ -1179,11 +1188,18 @@ function dnvm-install {
             else {
                 _WriteOut "Compiling native images for $runtimeFullName to improve startup performance..."
                 Write-Progress -Activity "Installing runtime" -Status "Generating runtime native images" -Id 1
+ 
+                if(Get-Command $CrossGenCommand -ErrorAction SilentlyContinue) {
+                    $crossGenCommand = $CrossGenCommand
+                } else {
+                    $crossGenCommand = $OldCrossGenCommand
+                }
+
                 if ($DebugPreference -eq 'SilentlyContinue') {
-                    Start-Process $CrossGenCommand -Wait -WindowStyle Hidden
+                    Start-Process $crossGenCommand -Wait -WindowStyle Hidden
                 }
                 else {
-                    Start-Process $CrossGenCommand -Wait -NoNewWindow
+                    Start-Process $crossGenCommand -Wait -NoNewWindow
                 }
                 _WriteOut "Finished native image compilation."
             }

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -91,6 +91,6 @@ $PSBoundParameters.Keys | ForEach-Object {
 }
 
 # Launch the script that will actually run the tests in a new shell
+& powershell -Version 2 -NoProfile -NoLogo -Command "& `"$PSScriptRoot\_Execute-Tests.ps1`" $childArgs -RunningInNewPowershell"
 & powershell -NoProfile -NoLogo -Command "& `"$PSScriptRoot\_Execute-Tests.ps1`" $childArgs -RunningInNewPowershell"
-
 exit $LASTEXITCODE

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -88,3 +88,34 @@ param(
     $wc.Proxy = $wp
   }
 }
+
+function Get-FileHash
+{
+    param ([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf))
+    {
+        return $null
+    }
+
+    $item = Get-Item -LiteralPath $Path
+    if ($item -isnot [System.IO.FileSystemInfo])
+    {
+        return $null
+    }
+
+    $stream = $null
+
+    try
+    {
+        $sha = New-Object System.Security.Cryptography.SHA256CryptoServiceProvider
+        $stream = $item.OpenRead()
+        $bytes = $sha.ComputeHash($stream)
+        return [convert]::ToBase64String($bytes)
+    }
+    finally
+    {
+        if ($null -ne $stream) { $stream.Close() }
+        if ($null -ne $sha)    { $sha.Clear() }
+    }
+}


### PR DESCRIPTION
Run tests on PSv2.0. 
Fix some behaviour that was discovered from test runs. 
Change temp path to include runtime name.
Added fallback for k-crossgen command.

/CC @anurse @muratg 