### PR TITLE
Only use ShowWindow when on PowerShell 3 or highter.

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -752,7 +752,11 @@ function dnvm-help {
             $Script:ExitCodes = $ExitCodes.UnknownCommand
             return
         }
-        $help = Get-Help "dnvm-$Command" -ShowWindow:$false
+        if($Host.Version.Major -lt 3) {
+            $help = Get-Help "dnvm-$Command"
+        } else {
+            $help = Get-Help "dnvm-$Command" -ShowWindow:$false
+        }
         if($PassThru -Or $Host.Version.Major -lt 3) {
             $help
         } else {
@@ -834,7 +838,11 @@ function dnvm-help {
         _WriteOut -ForegroundColor $ColorScheme.Help_Header "commands: "
         Get-Command "$CommandPrefix*" | 
             ForEach-Object {
-                $h = Get-Help $_.Name -ShowWindow:$false
+                if($Host.Version.MajorVersion -lt 3) {
+                    $h = Get-Help $_.Name
+                } else {
+                    $h = Get-Help $_.Name -ShowWindow:$false
+                }
                 $name = $_.Name.Substring($CommandPrefix.Length)
                 if($DeprecatedCommands -notcontains $name) {
                     _WriteOut -NoNewLine "    "

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -46,9 +46,9 @@ if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $scriptDir "../apps")
 # that dnvm can find it, download it and unpack it successfully. We do run an app in the runtime to do that sanity
 # test, but all we care about in these tests is that the app executes.
 $env:DNX_FEED = "https://www.myget.org/F/aspnetrelease/api/v2"
-$TestRuntimeVersion = "1.0.0-beta4-11566"
+$TestRuntimeVersion = "1.0.0-beta5-12021"
 $specificNupkgUrl = "$($env:DNX_FEED)/package/dnx-coreclr-win-x64/$TestRuntimeVersion"
-$specificNupkgHash = "AIHg5fmNneO9B4kyrtFi2oYRtKkEE3x09Inhu8N5xt4="
+$specificNupkgHash = "hZ7KoukWVu9m7UsmurcVtXVNvFiN9VaKFcRB9tkSBn4="
 $specificNupkgName = "dnx-coreclr-win-x64.$TestRuntimeVersion.nupkg"
 $specificNuPkgFxName = "Asp.Net,Version=v5.0"
 

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -26,8 +26,8 @@ source $COMMON_HELPERS
 export DNX_FEED
 
 # This is a DNX to use for testing various commands. It doesn't matter what version it is
-[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta4-11566"
-[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='113d4496a2b28399f36cc7b0c14fbb49701e511e'
+[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta5-12021"
+[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='f72ae5308456038e1a13d8816ef0aaaa4a545545'
 [ -z "$_NUPKG_URL" ]        && export _NUPKG_URL="$DNX_FEED/package/$_DNVM_RUNTIME_PACKAGE_NAME-mono/$_TEST_VERSION"
 [ -z "$_NUPKG_NAME" ]       && export _NUPKG_NAME="$_DNVM_RUNTIME_PACKAGE_NAME-mono.$_TEST_VERSION"
 [ -z "$_NUPKG_FILE" ]       && export _NUPKG_FILE="$TEST_WORK_DIR/${_NUPKG_NAME}.nupkg"


### PR DESCRIPTION
Update to beta5 now that it is on the release feed, otherwise compiling the test app breaks.
Stop using ShowWindow on PS2