### PR TITLE
build: Enables FreeBSD support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild

--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # dnvm.sh
 # Source this file from your .bash-profile or script to use
 

--- a/test/sh/chester
+++ b/test/sh/chester
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION="0.1.0"
 
 # A bunch of helper functions and variables!

--- a/test/sh/common.sh
+++ b/test/sh/common.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # A bunch of helper functions and variables!
 
 # "Constants"

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Determine my directory
 SCRIPT_DIR=$(dirname $0)

--- a/test/sh/tests/alias/Alias values can be retrieved.sh
+++ b/test/sh/tests/alias/Alias values can be retrieved.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/Aliases can be listed.sh
+++ b/test/sh/tests/alias/Aliases can be listed.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/Aliases can be removed.sh
+++ b/test/sh/tests/alias/Aliases can be removed.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/Aliases can be use-d.sh
+++ b/test/sh/tests/alias/Aliases can be use-d.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/Aliasing creates a new alias file.sh
+++ b/test/sh/tests/alias/Aliasing creates a new alias file.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/Aliasing replaces existing alias.sh
+++ b/test/sh/tests/alias/Aliasing replaces existing alias.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/alias/after_all.sh
+++ b/test/sh/tests/alias/after_all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Clean up
 rm -Rf "$DNX_USER_HOME/alias"
 rm -Rf "$DNX_USER_HOME/runtimes"

--- a/test/sh/tests/alias/before_all.sh
+++ b/test/sh/tests/alias/before_all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installed runtime can run hello app.sh
+++ b/test/sh/tests/install/Installed runtime can run hello app.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Simple smoke test for the runtime fetched by $_DNVM_COMMAND_NAME. To help ensure that it is unpacked correctly and such
 
 source $COMMON_HELPERS

--- a/test/sh/tests/install/Installing a runtime that exists does not report error.sh
+++ b/test/sh/tests/install/Installing a runtime that exists does not report error.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installing from nupkg unpacks nupkg as expected.sh
+++ b/test/sh/tests/install/Installing from nupkg unpacks nupkg as expected.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installing latest with no arguments installs Mono CLR.sh
+++ b/test/sh/tests/install/Installing latest with no arguments installs Mono CLR.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installing puts selected runtime on PATH.sh
+++ b/test/sh/tests/install/Installing puts selected runtime on PATH.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installing with alias switch creates specified alias.sh
+++ b/test/sh/tests/install/Installing with alias switch creates specified alias.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/Installing with persistant switch creates default alias.sh
+++ b/test/sh/tests/install/Installing with persistant switch creates default alias.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/install/after.sh
+++ b/test/sh/tests/install/after.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Clean up
 rm -Rf "$DNX_USER_HOME/alias"
 rm -Rf "$DNX_USER_HOME/runtimes"

--- a/test/sh/tests/sourcing/Sourcing the script adds the command.sh
+++ b/test/sh/tests/sourcing/Sourcing the script adds the command.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 
 source $_DNVM_PATH || die "$_DNVM_COMMAND_NAME sourcing failed"

--- a/test/sh/tests/use/Use-ing a non-existant alias produces an error.sh
+++ b/test/sh/tests/use/Use-ing a non-existant alias produces an error.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/use/Use-ing a non-existant version produces an error.sh
+++ b/test/sh/tests/use/Use-ing a non-existant version produces an error.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/use/Use-ing a version puts the matching runtime on the PATH.sh
+++ b/test/sh/tests/use/Use-ing a version puts the matching runtime on the PATH.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/use/Use-ing an alias puts the matching runtime on the path.sh
+++ b/test/sh/tests/use/Use-ing an alias puts the matching runtime on the path.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/use/Use-ing none clears runtime from the PATH.sh
+++ b/test/sh/tests/use/Use-ing none clears runtime from the PATH.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 

--- a/test/sh/tests/use/after_all.sh
+++ b/test/sh/tests/use/after_all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Clean up
 rm -Rf "$DNX_USER_HOME/alias"
 rm -Rf "$DNX_USER_HOME/runtimes"

--- a/test/sh/tests/use/before_all.sh
+++ b/test/sh/tests/use/before_all.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source $COMMON_HELPERS
 source $_DNVM_PATH
 


### PR DESCRIPTION
Changed hardcoded bash shebang to env to support multiple directory
structures (required to build on FreeBSD).

copy @josteink, @akoeplinger, @janhenke, @ajensenwaud, @saper