### PR TITLE
build: Enables FreeBSD support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild

--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -208,7 +208,7 @@ __dnvm_unpack() {
 
     #Set shell commands as executable
     find "$runtimeFolder/bin/" -type f \
-        -exec sh -c "head -c 11 {} | grep '/bin/bash' > /dev/null"  \; -print | xargs chmod 775
+        -exec sh -c "head -c 11 {} | grep '/usr/bin/env bash' > /dev/null"  \; -print | xargs chmod 775
 
     #Set dnx to be executable
     chmod 775 "$runtimeFolder/bin/dnx"

--- a/test/sh/chester
+++ b/test/sh/chester
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION="0.1.0"
 
 # A bunch of helper functions and variables!

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Determine my directory
 SCRIPT_DIR=$(dirname $0)


### PR DESCRIPTION
Changed hardcoded bash shebang to env to support multiple directory
structures (required to build on FreeBSD).
