### PR TITLE
Replace $Host.Version.MajorVersion with $Host.Version.Major

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -927,7 +927,7 @@ function dnvm-help {
         _WriteOut -ForegroundColor $ColorScheme.Help_Header "commands: "
         Get-Command "$CommandPrefix*" | 
             ForEach-Object {
-                if($Host.Version.MajorVersion -lt 3) {
+                if($Host.Version.Major -lt 3) {
                     $h = Get-Help $_.Name
                 } else {
                     $h = Get-Help $_.Name -ShowWindow:$false


### PR DESCRIPTION
One of the PowerShell host version checks was using the wrong property to evaluate the major version of the host.

A non-existent `$Host.Version.MajorVersion` is being called instead of `$Host.Version.Major`

This pull request updates that check to use the correct property. See other correct usages on lines 755 and 760.

This bug was introduced on 6/10/2015 with commit [21ce03f48a8fc8929957d3ddfba191b203754615](https://github.com/aspnet/dnvm/blame/21ce03f48a8fc8929957d3ddfba191b203754615/src/dnvm.ps1#L841).