### PR TITLE
fixed alias invalid.

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -342,8 +342,8 @@ function Get-RuntimeName(
     if(Test-Path $aliasPath) {
         $BaseName = Get-Content $aliasPath
 
-        $Architecture = GetArch $Architecture (Get-PackageArch $BaseName)
-        $Runtime = GetRuntime $Runtime (Get-PackageArch $BaseName)
+        $Architecture = GetArch ($Architecture, (Get-PackageArch $BaseName) -ne '')[0]
+        $Runtime = GetRuntime ($Runtime, (Get-PackageRuntime $BaseName) -ne '')[0]
         $Version = Get-PackageVersion $BaseName
     }
     


### PR DESCRIPTION
When you `run` or `exec` command uses the `alias` does not correct as to the corresponding runtime.