### PR TITLE
Fix dnvm upgrade in zsh

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -623,7 +623,12 @@ dnvm()
             local action="Setting"
             [[ -e "$_DNVM_ALIAS_DIR/$name.alias" ]] && action="Updating"
             echo "$action alias '$name' to '$runtimeFullName'"
-            echo "$runtimeFullName" > "$_DNVM_ALIAS_DIR/$name.alias"
+            
+            if [[ $SHELL == *"zsh"* ]]; then
+                echo "$runtimeFullName" >! "$_DNVM_ALIAS_DIR/$name.alias";
+            else
+                echo "$runtimeFullName" > "$_DNVM_ALIAS_DIR/$name.alias";
+            fi
         ;;
 
         "unalias" )


### PR DESCRIPTION
Must force overwrite to the alias file in zsh using `>!` instead of `>`.

Tested in both bash and zsh on OS X.