### PR TITLE
Quote $cmdargs string to prevent path errors

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -1848,10 +1848,17 @@ if(Test-Path env:\KRE_HOME) {
 
 $cmd = $args[0]
 
+$cmdargs = @()
 if($args.Length -gt 1) {
-    $cmdargs = @($args[1..($args.Length-1)])
-} else {
-    $cmdargs = @()
+    # Combine arguments, ensuring any containing whitespace or parenthesis are correctly quoted 
+    ForEach ($arg In $args[1..($args.Length-1)]) {
+        if ($arg -match "[\s\(\)]") {
+            $cmdargs += """$arg"""
+        } else {
+            $cmdargs += $arg
+        }
+        $cmdargs += " "
+    }
 }
 
 # Can't add this as script-level arguments because they mask '-a' arguments in subcommands!


### PR DESCRIPTION
Using the new release of VS 2015 an error is thrown in the DNVM output window when VS attempts to install a runtime when none was found in the user .dnx folder. 


```
Invoke-Command : The term 'x86' is not recognized as the name of a cmdlet, 
Invoke-Command : The term 'x86' is not recognized as the name of a cmdlet, 
function, script file, or operable program. Check the spelling of the name, or 
function, script file, or operable program. Check the spelling of the name, or 
if a path was included, verify that the path is correct and try again.
if a path was included, verify that the path is correct and try again.
At C:\Program Files\Microsoft DNX\Dnvm\dnvm.ps1:1488 char:9
+         Invoke-Command ([ScriptBlock]::Create("dnvm-$cmd $cmdargs"))
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (x86:String) [Invoke-Command], C 
   ommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException,Microsoft.PowerShell.Co 
   mmands.InvokeCommandCommand
```

This is caused by the script attempting to execute:

```
dnvm-install C:\Program Files (x86)\Microsoft Web Tools\DNX\dnx-clr-win-x86.1.0.0-beta5.nupkg
```

Naturally this path should be quoted. This MR resolves this by quoting the $cmdargs variable, resulting in the execution of:

```
dnvm-install "C:\Program Files (x86)\Microsoft Web Tools\DNX\dnx-clr-win-x86.1.0.0-beta5.nupkg"
```

And VS is once again happy.

A side effect of this bug (VS not being able to load DNX) is that all DNX projects are loaded as "Miscellaneous Files" and no intellisense is provided and builds within VS are broken. Restarting VS following copying the patched `dnvm.ps1` to `C:\Program Files\Microsoft DNX\Dnvm` resolves this.