### PR TITLE
 Fixed latest version retrieval on OS X

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -88,8 +88,8 @@ __dnvm_find_latest() {
         local packageId="$_DNVM_RUNTIME_PACKAGE_NAME-$platform-$(__dnvm_current_os)-$arch"
     fi
     local url="$DNX_ACTIVE_FEED/GetUpdates()?packageIds=%27$packageId%27&versions=%270.0%27&includePrerelease=true&includeAllVersions=false"
-    xml="$(curl $url 2>/dev/null)"
-    echo $xml | grep \<[a-zA-Z]:Version\>* >> /dev/null || return 1
+    xml=$(curl "$url" 2>/dev/null)
+    echo "$xml" | egrep "(\<[a-zA-Z]:Version\>)*" >> /dev/null || return 1
     version="$(echo $xml | sed 's/.*<[a-zA-Z]:Version>\([^<]*\).*/\1/')"
     echo $version
 }


### PR DESCRIPTION
I could not install dnx using dvnm.sh sourced in bash on OS X, using the main repo
https://github.com/aspnet/Home
(I wasn't able to build this repo on OS X.)

Console output
```
$ dnvm upgrade
Determining latest version
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
Error: Could not find latest version from feed https://www.nuget.org/api/v2
```

I'm running OS X Yosemite 10.10.4 and GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin14)

### Solution
However, I resolved the issue by editing two lines in dvnm.sh in function __dnvm_find_latest()
The latest version of dnx was not extracted due to wrong placements of quotes and an erraneous regex call to grep.

Before
```
91 -    xml="$(curl $url 2>/dev/null)"
92 -    echo $xml | grep \<[a-zA-Z]:Version\>* >> /dev/null || return 1
```
After
```
91 +    xml=$(curl "$url" 2>/dev/null)
92 +    echo "$xml" | egrep "(\<[a-zA-Z]:Version\>)*" >> /dev/null || return 1
```