### PR TITLE
Prevent DNX_HOME/bin to be added repeatedly to PATH when sourcing dnvm.sh

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -813,8 +813,8 @@ dnvm()
     return 0
 }
 
-# Add the home location's bin directory to the path
-export PATH="$DNX_HOME/bin:$PATH"
+# Add the home location's bin directory to the path if it doesn't exist
+[[ ":$PATH:" != *":$DNX_HOME/bin:"* ]] && export PATH="$DNX_HOME/bin:$PATH"
 
 # Generate the command function using the constant defined above.
 $_DNVM_COMMAND_NAME list default >/dev/null && $_DNVM_COMMAND_NAME use default >/dev/null || true

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -26,8 +26,8 @@ source $COMMON_HELPERS
 export DNX_FEED
 
 # This is a DNX to use for testing various commands. It doesn't matter what version it is
-[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta6-12208"
-[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='1e01296cdfcb94ab5eb22c658a6b1ec922cebd93'
+[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta8-15530"
+[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='1abc9039fbf10ec3eebc9af216be103ffd1ccb7b'
 [ -z "$_NUPKG_URL" ]        && export _NUPKG_URL="$DNX_FEED/package/$_DNVM_RUNTIME_PACKAGE_NAME-mono/$_TEST_VERSION"
 [ -z "$_NUPKG_NAME" ]       && export _NUPKG_NAME="$_DNVM_RUNTIME_PACKAGE_NAME-mono.$_TEST_VERSION"
 [ -z "$_NUPKG_FILE" ]       && export _NUPKG_FILE="$TEST_WORK_DIR/${_NUPKG_NAME}.nupkg"

--- a/test/sh/tests/run_exec/Executes the host or command for the specified alias.sh
+++ b/test/sh/tests/run_exec/Executes the host or command for the specified alias.sh
@@ -6,6 +6,6 @@ $_DNVM_COMMAND_NAME use none
 
 pushd "$TEST_APPS_DIR/TestApp"
 $_DNVM_COMMAND_NAME exec test_alias_runexec $_DNVM_PACKAGE_MANAGER_NAME restore || die "failed to restore packages"
-OUTPUT=$($_DNVM_COMMAND_NAME run test_alias_runexec . run || die "failed to run hello application")
+OUTPUT=$($_DNVM_COMMAND_NAME run test_alias_runexec run || die "failed to run hello application")
 echo $OUTPUT | grep 'Runtime is sane!' || die "unexpected output from sample app: $OUTPUT"
 popd

--- a/test/sh/tests/run_exec/Executes the host or command for the specified version.sh
+++ b/test/sh/tests/run_exec/Executes the host or command for the specified version.sh
@@ -5,6 +5,6 @@ $_DNVM_COMMAND_NAME use none
 
 pushd "$TEST_APPS_DIR/TestApp"
 $_DNVM_COMMAND_NAME exec $_TEST_VERSION $_DNVM_PACKAGE_MANAGER_NAME restore || die "failed to restore packages"
-OUTPUT=$($_DNVM_COMMAND_NAME run $_TEST_VERSION . run || die "failed to run hello application")
+OUTPUT=$($_DNVM_COMMAND_NAME run $_TEST_VERSION run || die "failed to run hello application")
 echo $OUTPUT | grep 'Runtime is sane!' || die "unexpected output from sample app: $OUTPUT"
 popd

--- a/test/sh/tests/sourcing/Sourcing the script twice does not add DNX_HOME bin to path twice.sh
+++ b/test/sh/tests/sourcing/Sourcing the script twice does not add DNX_HOME bin to path twice.sh
@@ -1,0 +1,7 @@
+source $COMMON_HELPERS
+
+source $_DNVM_PATH || die "$_DNVM_COMMAND_NAME sourcing failed"
+source $_DNVM_PATH || die "$_DNVM_COMMAND_NAME sourcing failed"
+
+MATCHES=$(echo $PATH | tr ":" "\n" | grep -c "$DNX_USER_HOME/bin")
+[[ $MATCHES -eq 1 ]] || die "sourcing $_DNVM_COMMAND_NAME twice did put '$DNX_USER_HOME/bin' on PATH $MATCHES times"


### PR DESCRIPTION
Fixes #412 

I also needed to update the dnx-mono nupkg used in tests to a newer version. Didn't seem to find old beta6-12208 on feed anymore. Added this as separate commit.

//cc @dougbu @BrennanConroy @anurse 