### PR TITLE
Fixed dnvm list x-plat inconsistency. 'Arch' renamed to 'Architecture…

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -763,13 +763,33 @@ dnvm()
             fi
 
             if [[ $2 == "-detailed" ]]; then
-                local formatString="%-6s %-20s %-7s %-4s %-15s %-20s %s\n"
-                printf "$formatString" "Active" "Version" "Runtime" "Arch" "OperatingSystem" "Location" "Alias"
-                printf "$formatString" "------" "-------" "-------" "----" "---------------" "--------" "-----"
+                # Calculate widest alias
+                local widestAlias=5
+                for f in `echo $runtimes`; do
+                    local pkgName=$(__dnvm_package_name "$f")
+                    local pkgVersion=$(__dnvm_package_version "$f")
+                    local alias=""
+                    local delim=""
+                    for i in "${arr[@]}"; do
+                        if [[ ${i##*/} == "$pkgName.$pkgVersion" ]]; then
+                            alias+="$delim${i%%/*}"
+                            delim=", "
+                            if [[ "${i%/*}" =~ \/missing$ ]]; then
+                                alias+=" (missing)"
+                            fi
+                        fi
+                    done
+                    if [ "${#alias}" -gt "$widestAlias" ]; then
+                        widestAlias=${#alias}
+                    fi
+                done
+                local formatString="%-6s %-20s %-7s %-12s %-15s %-${widestAlias}s %s\n"
+                printf "$formatString" "Active" "Version" "Runtime" "Architecture" "OperatingSystem" "Alias" "Location"
+                printf "$formatString" "------" "-------" "-------" "------------" "---------------" "-----" "--------"
             else
-                local formatString="%-6s %-20s %-7s %-4s %-15s %s\n"
-                printf "$formatString" "Active" "Version" "Runtime" "Arch" "OperatingSystem" "Alias"
-                printf "$formatString" "------" "-------" "-------" "----" "---------------" "-----"
+                local formatString="%-6s %-20s %-7s %-12s %-15s %s\n"
+                printf "$formatString" "Active" "Version" "Runtime" "Architecture" "OperatingSystem" "Alias"
+                printf "$formatString" "------" "-------" "-------" "------------" "---------------" "-----"
             fi
 
             for f in `echo $runtimes  | sort -t. -k2 -k3 -k4 -k1`; do
@@ -796,7 +816,7 @@ dnvm()
                 done
 
                 if [[ $2 == "-detailed" ]]; then
-                    printf "$formatString" "$active" "$pkgVersion" "$pkgRuntime" "$pkgArch" "$pkgOs" "$formattedHome" "$alias"
+                    printf "$formatString" "$active" "$pkgVersion" "$pkgRuntime" "$pkgArch" "$pkgOs" "$alias" "$formattedHome"
                 else
                     printf "$formatString" "$active" "$pkgVersion" "$pkgRuntime" "$pkgArch" "$pkgOs" "$alias"
                 fi

--- a/test/sh/tests/list/Listing displays orphaned aliases.sh
+++ b/test/sh/tests/list/Listing displays orphaned aliases.sh
@@ -13,4 +13,4 @@ echo dnx-foo-bar.1.0.0-beta7 > $DNX_USER_HOME/alias/foobar.alias
 # List runtimes
 OUTPUT=$($_DNVM_COMMAND_NAME list -detailed || die "failed at listing runtimes")
 echo $OUTPUT | grep -E "\s+1\.0\.0-beta7\s+foo\s+bar\s+foobar\s\(missing\)" || die "expected message was not reported"
-echo $OUTPUT | grep -E "\/runtimes\s+default" || die "expected message was not reported"
+echo $OUTPUT | grep -E "default\s+.*?\/runtimes" || die "expected message was not reported"


### PR DESCRIPTION
…', 'Location' moved as last column when using -detailed flag

Fixes #390 

Tests will fail since beta6-12208 can't be found anymore. Merge #415 prior to this to fix that issue.

//cc @BrennanConroy @anurse 