### PR TITLE
Allow overriding architecture and runtime during `dnvm use`

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -400,8 +400,12 @@ function Get-RuntimeAliasOrRuntimeInfo(
     if(Test-Path $aliasPath) {
         $BaseName = Get-Content $aliasPath
 
-        $Architecture = Get-PackageArch $BaseName
-        $Runtime = Get-PackageRuntime $BaseName
+        if(!$Architecture) {
+            $Architecture = Get-PackageArch $BaseName
+        }
+        if(!$Runtime) {
+            $Runtime = Get-PackageRuntime $BaseName
+        }
         $Version = Get-PackageVersion $BaseName
         $OS = Get-PackageOS $BaseName
     }
@@ -1542,7 +1546,7 @@ function dnvm-use {
         return;
     }
     
-    $runtimeInfo = Get-RuntimeAliasOrRuntimeInfo -Version:$VersionOrAlias -Architecture:$Architecture -Runtime:$Runtime -OS:$OS 
+    $runtimeInfo = Get-RuntimeAliasOrRuntimeInfo -Version:$VersionOrAlias -Architecture:$Architecture -Runtime:$Runtime -OS:$OS
     $runtimeFullName = $runtimeInfo.RuntimeName
     $runtimeBin = Get-RuntimePath $runtimeFullName
     if ($runtimeBin -eq $null) {

--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -328,24 +328,30 @@ __dnvm_requested_version_or_alias() {
     else
         if [ -e "$_DNVM_ALIAS_DIR/$versionOrAlias.alias" ]; then
             local runtimeFullName=$(cat "$_DNVM_ALIAS_DIR/$versionOrAlias.alias")
-            echo "$runtimeFullName"
-        else
-            local pkgVersion=$versionOrAlias
-            local pkgArchitecture="x64"
-            local pkgSystem=$os
-
-            if [[ -z $runtime || "$runtime" == "mono" ]]; then
-                echo "$_DNVM_RUNTIME_PACKAGE_NAME-mono.$pkgVersion"
-            else
-                if [ "$arch" != "" ]; then
-                    local pkgArchitecture="$arch"
-                fi
-                if [ "$os" == "" ]; then
-                    local pkgSystem=$(__dnvm_current_os)
-                fi
-
-                echo "$_DNVM_RUNTIME_PACKAGE_NAME-$runtime-$pkgSystem-$pkgArchitecture.$pkgVersion"
+            if [[ ! -n "$runtime" && ! -n "$arch" ]]; then
+                echo "$runtimeFullName"
+                return
             fi
+            local pkgVersion=$(__dnvm_package_version "$runtimeFullName")
+        fi
+
+        if [[ ! -n "$pkgVersion" ]]; then
+            local pkgVersion=$versionOrAlias
+        fi
+        local pkgArchitecture="x64"
+        local pkgSystem=$os
+
+        if [[ -z $runtime || "$runtime" == "mono" ]]; then
+            echo "$_DNVM_RUNTIME_PACKAGE_NAME-mono.$pkgVersion"
+        else
+            if [ "$arch" != "" ]; then
+                local pkgArchitecture="$arch"
+            fi
+            if [ "$os" == "" ]; then
+                local pkgSystem=$(__dnvm_current_os)
+            fi
+
+            echo "$_DNVM_RUNTIME_PACKAGE_NAME-$runtime-$pkgSystem-$pkgArchitecture.$pkgVersion"
         fi
     fi
 }

--- a/test/ps1/tests/Use.Tests.ps1
+++ b/test/ps1/tests/Use.Tests.ps1
@@ -1,5 +1,6 @@
 # Ensure some KREs have been installed (if the other tests ran first, we're good)
 __dnvmtest_run install $TestRuntimeVersion -arch "x86" -r "CLR"
+__dnvmtest_run install $TestRuntimeVersion -arch "x64" -r "CoreCLR"
 
 $notRealRuntimeVersion = "0.0.1-notarealruntime"
 
@@ -58,6 +59,17 @@ Describe "use" -Tag "use" {
             $cmd | Should Not BeNullOrEmpty
             $cmd.Definition | Should Be (Convert-Path "$UserPath\runtimes\$runtimeName\bin\$RuntimeHostName")
         }
+    }
+    
+    Context "When use-ing an ailas, overriding -arch and -r" {
+        __dnvmtest_run use $testAlias -arch "x64" -r "CoreCLR" | Out-Null
+        $runtimeName = GetRuntimeName -clr CoreCLR -arch x64
+
+        It "uses x64/CoreCLR variant" {
+            GetActiveRuntimeName | Should Be $runtimeName
+        }
+
+        __dnvmtest_run use none | Out-Null
     }
 
     Context "When use-ing 'none'" {


### PR DESCRIPTION
Fixes #405

@anurse I can't seem to run the tests locally, so I 'm not sure if the one I wrote is correct. I manually verified that the product changes work, however.