### PR TITLE
Check if directory exist before executing find

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -762,7 +762,7 @@ dnvm()
             local name="$1"
 
             if [[ $# == 1 ]]; then
-                [[ ! -e "$_DNVM_ALIAS_DIR/$name.alias" ]] && echo "There is no alias called '$name'" && return
+                [[ ! -e "$_DNVM_ALIAS_DIR/$name.alias" ]] && echo "There is no alias called '$name'" && return 1
                 cat "$_DNVM_ALIAS_DIR/$name.alias"
                 echo ""
                 return
@@ -925,4 +925,4 @@ dnvm()
 [[ ":$PATH:" != *":$DNX_USER_HOME/bin:"* ]] && export PATH="$DNX_USER_HOME/bin:$PATH"
 
 # Generate the command function using the constant defined above.
-$_DNVM_COMMAND_NAME list default >/dev/null && $_DNVM_COMMAND_NAME use default >/dev/null || true
+$_DNVM_COMMAND_NAME alias default >/dev/null && $_DNVM_COMMAND_NAME use default >/dev/null || true

--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -816,10 +816,12 @@ dnvm()
             local runtimes=""
             for location in `echo $DNX_HOME | tr ":" "\n"`; do
                 location+="/runtimes"
-                local oruntimes="$(find $location -name "$searchGlob" \( -type d -or -type l \) -prune -exec basename {} \;)"
-                for v in `echo $oruntimes | tr "\n" " "`; do
-                    runtimes+="$v:$location"$'\n'
-                done
+                if [ -d "$location" ]; then
+                    local oruntimes="$(find $location -name "$searchGlob" \( -type d -or -type l \) -prune -exec basename {} \;)"
+                    for v in `echo $oruntimes | tr "\n" " "`; do
+                        runtimes+="$v:$location"$'\n'
+                    done
+                fi
             done
 
             [[ -z $runtimes ]] && echo 'No runtimes installed. You can run `dnvm install latest` or `dnvm upgrade` to install a runtime.' && return


### PR DESCRIPTION
Fixes #425 by checking if directory exist before executing find. If e.g. global install dir is not present, one will get "find: `/usr/local/lib/dnx/runtimes': No such file or directory" error message everytime opening a terminal or running dnvm list.