### PR TITLE
dnvm alias allows updating existing alias if noclobber is set

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -793,7 +793,7 @@ dnvm()
             local action="Setting"
             [[ -e "$_DNVM_ALIAS_DIR/$name.alias" ]] && action="Updating"
             echo "$action alias '$name' to '$runtimeFullName'"
-            echo "$runtimeFullName" > "$_DNVM_ALIAS_DIR/$name.alias"
+            echo "$runtimeFullName" >| "$_DNVM_ALIAS_DIR/$name.alias"
         ;;
 
         "unalias" )

--- a/test/sh/tests/alias/Aliasing replaces existing alias.sh
+++ b/test/sh/tests/alias/Aliasing replaces existing alias.sh
@@ -1,6 +1,15 @@
 source $COMMON_HELPERS
 source $_DNVM_PATH
 
+# Check which shell currently executing
+if [ -n "$ZSH_VERSION" ]; then
+    # assume Zsh
+    setopt noclobber
+elif [ -n "$BASH_VERSION" ]; then
+    # assume Bash
+    set -o noclobber
+fi
+
 echo "woozlewuzzle" > "$DNX_USER_HOME/alias/test_alias_rename.alias"
 
 # Alias the installed runtime


### PR DESCRIPTION
Fixes #423 

@anurse would it be beneficial to run all tests with ```noclobber``` option?

Accoring to the [Unix Power Tools Book](https://books.google.fi/books?id=Xk6THylQxRUC&lpg=SA43-PA6&dq=safe%20I%2FO%20redirection%20with%20noclobber&pg=SA43-PA6#v=onepage&q=safe%20I/O%20redirection%20with%20noclobber&f=false) the Z shell understands both ```!```and ```|```, therefore I'm not using any shell checking in ```dnvm.sh```

Regarding checking current shell, unlike the original PR, I'm not checking ```$SHELL``` variable as this will only return default shell, therefore checking ```$BASH_VERSION``` or ```$ZSH_VERSION``` would be more safe.