### PR TITLE
Fix for dnvm update-self on PowerShell 2.0

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -846,6 +846,14 @@ function Is-Elevated() {
     return $user.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
 }
 
+function Get-ScriptRoot() {
+    if (!$PSVersionTable.PSVersion.Major -ge 3) {
+        return $PSScriptRoot
+    }
+
+    return Split-Path $script:MyInvocation.MyCommand.Path -Parent
+}
+
 ### Commands
 
 <#
@@ -862,10 +870,11 @@ function dnvm-update-self {
     _WriteOut "Updating $CommandName from $DNVMUpgradeUrl"
     $wc = New-Object System.Net.WebClient
     Apply-Proxy $wc -Proxy:$Proxy
-
-    $dnvmFile = Join-Path $PSScriptRoot "dnvm.ps1"
-    $tempDnvmFile = Join-Path $PSScriptRoot "temp"
-    $backupFilePath = Join-Path $PSSCriptRoot "dnvm.ps1.bak"
+	
+	$CurrentScriptRoot = Get-ScriptRoot
+    $dnvmFile = Join-Path $CurrentScriptRoot "dnvm.ps1"
+    $tempDnvmFile = Join-Path $CurrentScriptRoot "temp"
+    $backupFilePath = Join-Path $CurrentScriptRoot "dnvm.ps1.bak"
 
     $wc.DownloadFile($DNVMUpgradeUrl, $tempDnvmFile)
 

--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -870,8 +870,8 @@ function dnvm-update-self {
     _WriteOut "Updating $CommandName from $DNVMUpgradeUrl"
     $wc = New-Object System.Net.WebClient
     Apply-Proxy $wc -Proxy:$Proxy
-	
-	$CurrentScriptRoot = Get-ScriptRoot
+
+    $CurrentScriptRoot = Get-ScriptRoot
     $dnvmFile = Join-Path $CurrentScriptRoot "dnvm.ps1"
     $tempDnvmFile = Join-Path $CurrentScriptRoot "temp"
     $backupFilePath = Join-Path $CurrentScriptRoot "dnvm.ps1.bak"

--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -847,7 +847,7 @@ function Is-Elevated() {
 }
 
 function Get-ScriptRoot() {
-    if (!$PSVersionTable.PSVersion.Major -ge 3) {
+    if ($PSVersionTable.PSVersion.Major -ge 3) {
         return $PSScriptRoot
     }
 


### PR DESCRIPTION
This changeset consist of two fixes for dnvm update-self when executed on PowerShell 2.0:
- PSScriptRoot variable is not available in PowerShell 2.0. This change sets a value for this variable if it is not set or empty.
- When DNX_HOME environmental variable has not been set yet the script will put a semicolon at the beginning of the value. This change removes empty entries when splitting the string by ';'

Fix for:
#391
#422