### PR TITLE
Reorder `dnvm.ps1` blocks to avoid read-before-write issues

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetlitedev/" />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcidev/" />
     <add key="NuGet.org" value="https://nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -109,8 +109,8 @@ Set-Variable -Option Constant "DNVMUpgradeUrl" "https://raw.githubusercontent.co
 Set-Variable -Option Constant "AsciiArt" @"
    ___  _  ___   ____  ___
   / _ \/ |/ / | / /  |/  /
- / // /    /| |/ / /|_/ / 
-/____/_/|_/ |___/_/  /_/  
+ / // /    /| |/ / /|_/ /
+/____/_/|_/ |___/_/  /_/
 "@
 
 $ExitCodes = @{
@@ -154,11 +154,11 @@ if($__TeeTo) {
 $DeprecatedCommands = @("unalias")
 
 # Load Environment variables
-$RuntimeHomes = $env:DNX_HOME
+$RuntimeHomes = $(if (Test-Path "env:\$HomeEnvVar") {Get-Content "env:\$HomeEnvVar"})
 $UserHome = $env:DNX_USER_HOME
 $GlobalHome = $env:DNX_GLOBAL_HOME
-$ActiveFeed = $env:DNX_FEED
-$ActiveUnstableFeed = $env:DNX_UNSTABLE_FEED
+$ActiveFeed = $(if (Test-Path "env:\$DefaultFeedKey") {Get-Content "env:\$DefaultFeedKey"})
+$ActiveUnstableFeed = $(if (Test-Path "env:\$DefaultUnstableFeedKey") {Get-Content "env:\$DefaultUnstableFeedKey"})
 
 # Default Exit Code
 $Script:ExitCode = $ExitCodes.Success
@@ -181,13 +181,32 @@ if($CmdPathFile) {
     _WriteDebug "Using CMD PATH file: $CmdPathFile"
 }
 
-# Determine where runtimes can exist (RuntimeHomes)
-if(!$RuntimeHomes) {
-    # Set up a default value for the runtime home
-    $UnencodedHomes = "$env:USERPROFILE\$DefaultUserDirectoryName;$GlobalHome\$DefaultGlobalDirectoryName"
-} else {
-    $UnencodedHomes = $RuntimeHomes
+# Determine the default installation directory (UserHome)
+if(!$UserHome) {
+    if ($RuntimeHomes) {
+      _WriteDebug "Detecting User Home..."
+      $pf = $env:ProgramFiles
+      if(Test-Path "env:\ProgramFiles(x86)") {
+          $pf32 = Get-Content "env:\ProgramFiles(x86)"
+      }
+
+      # Canonicalize so we can do StartsWith tests
+      if(!$pf.EndsWith("\")) { $pf += "\" }
+      if($pf32 -and !$pf32.EndsWith("\")) { $pf32 += "\" }
+
+      $UserHome = $RuntimeHomes.Split(";") | Where-Object {
+          # Take the first path that isn't under program files
+          !($_.StartsWith($pf) -or $_.StartsWith($pf32))
+      } | Select-Object -First 1
+
+      _WriteDebug "Found: $UserHome"
+    }
+
+    if(!$UserHome) {
+        $UserHome = "$DefaultUserHome"
+    }
 }
+$UserHome = [Environment]::ExpandEnvironmentVariables($UserHome)
 
 # Determine the default global installation directory (GlobalHome)
 if(!$GlobalHome) {
@@ -196,39 +215,27 @@ if(!$GlobalHome) {
     } else {
         $GlobalHome = "$env:AllUsersProfile\$DefaultGlobalDirectoryName"
     }
+}
+$GlobalHome = [Environment]::ExpandEnvironmentVariables($GlobalHome)
 
-    $env:DNX_GLOBAL_HOME="$GlobalHome"
-    $env:DNX_HOME="$env:DNX_HOME;$env:DNX_GLOBAL_HOME"
-    $UnencodedHomes = "$UnencodedHomes;$GlobalHome"
+# Determine where runtimes can exist (RuntimeHomes)
+if(!$RuntimeHomes) {
+    # Set up a default value for the runtime home
+    $UnencodedHomes = "$UserHome;$GlobalHome"
+} elseif ($RuntimeHomes.StartsWith(';')) {
+    _WriteOut "Ignoring invalid $HomeEnvVar; value was '$RuntimeHomes'" -ForegroundColor $ColorScheme.Warning
+    Set-Content "env:\$HomeEnvVar" $null
+    [Environment]::SetEnvironmentVariable($HomeEnvVar, $null, "User")
+
+    # Use default instead.
+    $UnencodedHomes = "$UserHome;$GlobalHome"
+} else {
+    $UnencodedHomes = $RuntimeHomes
 }
 
 $UnencodedHomes = $UnencodedHomes.Split(";")
 $RuntimeHomes = $UnencodedHomes | ForEach-Object { [Environment]::ExpandEnvironmentVariables($_) }
 $RuntimeDirs = $RuntimeHomes | ForEach-Object { Join-Path $_ "runtimes" }
-
-# Determine the default installation directory (UserHome)
-if(!$UserHome) {
-    _WriteDebug "Detecting User Home..."
-    $pf = $env:ProgramFiles
-    if(Test-Path "env:\ProgramFiles(x86)") {
-        $pf32 = Get-Content "env:\ProgramFiles(x86)"
-    }
-
-    # Canonicalize so we can do StartsWith tests
-    if(!$pf.EndsWith("\")) { $pf += "\" }
-    if($pf32 -and !$pf32.EndsWith("\")) { $pf32 += "\" }
-
-    $UserHome = $RuntimeHomes | Where-Object {
-        # Take the first path that isn't under program files
-        !($_.StartsWith($pf) -or $_.StartsWith($pf32))
-    } | Select-Object -First 1
-
-    _WriteDebug "Found: $UserHome"
-    
-    if(!$UserHome) {
-        $UserHome = "$env:USERPROFILE\$DefaultUserDirectoryName"
-    }
-}
 
 _WriteDebug ""
 _WriteDebug "=== Running $CommandName ==="
@@ -241,17 +248,17 @@ $Aliases = $null
 
 ### Helper Functions
 # Checks if a specified file exists in the destination folder and if not, copies the file
-# to the destination folder. 
+# to the destination folder.
 function Safe-Filecopy {
     param(
-        [Parameter(Mandatory=$true, Position=0)] $Filename, 
+        [Parameter(Mandatory=$true, Position=0)] $Filename,
         [Parameter(Mandatory=$true, Position=1)] $SourceFolder,
         [Parameter(Mandatory=$true, Position=2)] $DestinationFolder)
 
     # Make sure the destination folder is created if it doesn't already exist.
     if(!(Test-Path $DestinationFolder)) {
         _WriteOut "Creating destination folder '$DestinationFolder' ... "
-        
+
         New-Item -Type Directory $Destination | Out-Null
     }
 
@@ -269,7 +276,7 @@ function Safe-Filecopy {
         }
     }
     else {
-        _WriteOut "WARNING: Unable to install: Could not find '$Filename' in '$SourceFolder'. " 
+        _WriteOut "WARNING: Unable to install: Could not find '$Filename' in '$SourceFolder'. "
     }
 }
 
@@ -313,9 +320,9 @@ function GetRuntimeInfo($Architecture, $Runtime, $OS, $Version) {
     if([String]::IsNullOrEmpty($runtimeInfo.Architecture)) {
         $runtimeInfo.Architecture = $RuntimeBitnessDefaults.Get_Item($RuntimeInfo.Runtime)
     }
-    
+
     $runtimeObject = New-Object PSObject -Property $runtimeInfo
-    
+
     $runtimeObject | Add-Member -MemberType ScriptProperty -Name RuntimeId -Value {
         if($this.Runtime -eq "mono") {
             "$RuntimePackageName-$($this.Runtime)".ToLowerInvariant()
@@ -409,8 +416,8 @@ function Get-RuntimeAliasOrRuntimeInfo(
         $Version = Get-PackageVersion $BaseName
         $OS = Get-PackageOS $BaseName
     }
-    
-    GetRuntimeInfo $Architecture $Runtime $OS $Version 
+
+    GetRuntimeInfo $Architecture $Runtime $OS $Version
 }
 
 filter List-Parts {
@@ -500,7 +507,7 @@ function Write-Alias {
 
     $aliasFilePath = Join-Path $AliasesDir "$Name.txt"
     $action = if (Test-Path $aliasFilePath) { "Updating" } else { "Setting" }
-    
+
     if(!(Test-Path $AliasesDir)) {
         _WriteDebug "Creating alias directory: $AliasesDir"
         New-Item -Type Directory $AliasesDir | Out-Null
@@ -636,11 +643,11 @@ function Download-Package() {
         [string]$Feed,
         [string]$Proxy
     )
-    
+
     _WriteOut "Downloading $($runtimeInfo.RuntimeName) from $feed"
     $wc = New-Object System.Net.WebClient
     try {
-      Apply-Proxy $wc -Proxy:$Proxy     
+      Apply-Proxy $wc -Proxy:$Proxy
       _WriteDebug "Downloading $DownloadUrl ..."
 
       Register-ObjectEvent $wc DownloadProgressChanged -SourceIdentifier WebClient.ProgressChanged -action {
@@ -706,7 +713,7 @@ function Unpack-Package([string]$DownloadFile, [string]$UnpackFolder) {
       }
     } else {
         [System.IO.Compression.ZipFile]::ExtractToDirectory($DownloadFile, $UnpackFolder)
-        
+
         # Clean up the package file itself.
         Remove-Item $DownloadFile -Force
     }
@@ -742,7 +749,7 @@ function Change-Path() {
         [string[]] $removePaths
     )
     _WriteDebug "Updating value to prepend '$prependPath' and remove '$removePaths'"
-    
+
     $newPath = $prependPath
     foreach($portion in $existingPaths.Split(';')) {
         if(![string]::IsNullOrEmpty($portion)) {
@@ -834,13 +841,13 @@ function Is-Elevated() {
 #>
 function dnvm-update-self {
     param(
-        [Parameter(Mandatory=$false)] 
+        [Parameter(Mandatory=$false)]
         [string]$Proxy)
 
     _WriteOut "Updating $CommandName from $DNVMUpgradeUrl"
     $wc = New-Object System.Net.WebClient
     Apply-Proxy $wc -Proxy:$Proxy
-    
+
     $dnvmFile = Join-Path $PSScriptRoot "dnvm.ps1"
     $tempDnvmFile = Join-Path $PSScriptRoot "temp"
     $backupFilePath = Join-Path $PSSCriptRoot "dnvm.ps1.bak"
@@ -899,7 +906,7 @@ function dnvm-help {
                         }
 
                         _WriteOut -NoNewLine " "
-                        
+
                         if($_.required -ne "true") {
                             _WriteOut -NoNewLine -ForegroundColor $ColorScheme.Help_Optional "["
                         }
@@ -909,7 +916,7 @@ function dnvm-help {
                         }
                         if($_.parameterValue) {
                             if($_.position -eq "Named") {
-                                _WriteOut -NoNewLine " "       
+                                _WriteOut -NoNewLine " "
                             }
                             _WriteOut -NoNewLine -ForegroundColor $ColorScheme.Help_Argument "<$($_.name)>"
                         }
@@ -931,9 +938,9 @@ function dnvm-help {
                     if($cmdParam.Aliases.Length -gt 0) {
                         $name = $cmdParam.Aliases | Sort-Object | Select-Object -First 1
                     }
-                    
+
                     _WriteOut -NoNewLine "  "
-                    
+
                     if($_.position -eq "Named") {
                         _WriteOut -NoNewLine -ForegroundColor $ColorScheme.Help_Switch "-$name".PadRight($OptionPadding)
                     } else {
@@ -946,7 +953,7 @@ function dnvm-help {
             if($help.description) {
                 _WriteOut
                 _WriteOut -ForegroundColor $ColorScheme.Help_Header "remarks:"
-                $help.description.Text.Split(@("`r", "`n"), "RemoveEmptyEntries") | 
+                $help.description.Text.Split(@("`r", "`n"), "RemoveEmptyEntries") |
                     ForEach-Object { _WriteOut "  $_" }
             }
 
@@ -959,7 +966,7 @@ function dnvm-help {
         Write-Feeds
         _WriteOut
         _WriteOut -ForegroundColor $ColorScheme.Help_Header "commands: "
-        Get-Command "$CommandPrefix*" | 
+        Get-Command "$CommandPrefix*" |
             ForEach-Object {
                 if($Host.Version.Major -lt 3) {
                     $h = Get-Help $_.Name
@@ -981,7 +988,7 @@ filter ColorActive {
     $lines = $_.Split("`n")
     foreach($line in $lines) {
         if($line.Contains("*")){
-            _WriteOut -ForegroundColor $ColorScheme.ActiveRuntime $line 
+            _WriteOut -ForegroundColor $ColorScheme.ActiveRuntime $line
         } else {
             _WriteOut $line
         }
@@ -1032,12 +1039,12 @@ function dnvm-list {
         if($items) {
             #TODO: Probably a better way to do this.
             if($Detailed) {
-                $items | 
-                    Sort-Object Version, Runtime, Architecture, OperatingSystem, Alias | 
+                $items |
+                    Sort-Object Version, Runtime, Architecture, OperatingSystem, Alias |
                     Format-Table -AutoSize -Property @{name="Active";expression={if($_.Active) { "*" } else { "" }};alignment="center"}, "Version", "Runtime", "Architecture", "OperatingSystem", "Alias", "Location" | Out-String| ColorActive
             } else {
-                $items | 
-                    Sort-Object Version, Runtime, Architecture, OperatingSystem, Alias | 
+                $items |
+                    Sort-Object Version, Runtime, Architecture, OperatingSystem, Alias |
                     Format-Table -AutoSize -Property @{name="Active";expression={if($_.Active) { "*" } else { "" }};alignment="center"}, "Version", "Runtime", "Architecture", "OperatingSystem", "Alias" | Out-String | ColorActive
             }
         } else {
@@ -1068,7 +1075,7 @@ function dnvm-list {
     (defaults to 'x86') and <Runtime> (defaults to 'clr').
 
     Finally, if the '-d' switch is provided, the alias <Name> is deleted, if it exists.
-    
+
     NOTE: You cannot create an alias for a non-windows runtime. The intended use case for
     an alias to help make it easier to switch the runtime, and you cannot use a non-windows
     runtime on a windows machine.
@@ -1092,7 +1099,7 @@ function dnvm-alias {
         [ValidateSet("", "clr","coreclr", "mono")]
         [Parameter(ParameterSetName="Write")]
         [string]$Runtime = "",
-            
+
         [ValidateSet("win", "osx", "darwin", "linux")]
         [Parameter(Mandatory=$false,ParameterSetName="Write")]
         [string]$OS = "")
@@ -1146,7 +1153,7 @@ function dnvm-unalias {
 .PARAMETER Ngen
     For CLR flavor only. Generate native images for runtime libraries on Desktop CLR to improve startup time. This option requires elevated privilege and will be automatically turned on if the script is running in administrative mode. To opt-out in administrative mode, use -NoNative switch.
 .PARAMETER Unstable
-    Upgrade from the unstable dev feed. This will give you the latest development version of the runtime. 
+    Upgrade from the unstable dev feed. This will give you the latest development version of the runtime.
 .PARAMETER Global
     Installs to configured global dnx file location (default: C:\ProgramData)
 #>
@@ -1165,7 +1172,7 @@ function dnvm-upgrade {
         [ValidateSet("", "clr", "coreclr")]
         [Parameter(Mandatory=$false)]
         [string]$Runtime = "",
-        
+
         [ValidateSet("", "win", "osx", "darwin", "linux")]
         [Parameter(Mandatory=$false)]
         [string]$OS = "",
@@ -1185,7 +1192,7 @@ function dnvm-upgrade {
 
         [Parameter(Mandatory=$false)]
         [switch]$Unstable,
-        
+
         [Parameter(Mandatory=$false)]
         [switch]$Global)
 
@@ -1322,7 +1329,7 @@ function dnvm-install {
             if([String]::IsNullOrEmpty($Architecture)) {
                 $Architecture = Get-PackageArch $BaseName
             }
-            
+
             if([String]::IsNullOrEmpty($Runtime)) {
                 $Runtime = Get-PackageRuntime $BaseName
             }
@@ -1330,7 +1337,7 @@ function dnvm-install {
             if([String]::IsNullOrEmpty($Version)) {
                 $Version = Get-PackageVersion $BaseName
             }
-            
+
             if([String]::IsNullOrEmpty($OS)) {
                 $OS = Get-PackageOS $BaseName
             }
@@ -1395,12 +1402,12 @@ function dnvm-install {
         }
     }
     else {
-         
+
         $Architecture = $runtimeInfo.Architecture
         $Runtime = $runtimeInfo.Runtime
         $OS = $runtimeInfo.OS
-        
-        $TempFolder = Join-Path $installDir "temp" 
+
+        $TempFolder = Join-Path $installDir "temp"
         $UnpackFolder = Join-Path $TempFolder $runtimeFullName
         $DownloadFile = Join-Path $UnpackFolder "$runtimeFullName.nupkg"
 
@@ -1450,7 +1457,7 @@ function dnvm-install {
         if($runtimeInfo.OS -eq "win") {
             dnvm-use $runtimeInfo.Version -Architecture:$runtimeInfo.Architecture -Runtime:$runtimeInfo.Runtime -Persistent:$Persistent -OS:$runtimeInfo.OS
         }
-        
+
         if ($runtimeInfo.Runtime -eq "clr") {
             if (-not $NoNative) {
                 if ((Is-Elevated) -or $Ngen) {
@@ -1470,7 +1477,7 @@ function dnvm-install {
             else {
                 _WriteOut "Compiling native images for $($runtimeInfo.RuntimeName) to improve startup performance..."
                 Write-Progress -Activity "Installing runtime" -Status "Generating runtime native images" -Id 1
- 
+
                 if(Get-Command $CrossGenCommand -ErrorAction SilentlyContinue) {
                     $crossGenCommand = $CrossGenCommand
                 } else {
@@ -1532,7 +1539,7 @@ function dnvm-use {
         [ValidateSet("", "clr", "coreclr")]
         [Parameter(Mandatory=$false)]
         [string]$Runtime = "",
-        
+
         [ValidateSet("", "win", "osx", "darwin", "linux")]
         [Parameter(Mandatory=$false)]
         [string]$OS = "",
@@ -1543,17 +1550,17 @@ function dnvm-use {
 
     if ($versionOrAlias -eq "none") {
         _WriteOut "Removing all runtimes from process PATH"
-        Set-Path (Change-Path $env:Path "" ($RuntimeDirs))
+        Set-Path (Change-Path $env:Path "" $RuntimeDirs)
 
         if ($Persistent) {
             _WriteOut "Removing all runtimes from user PATH"
             $userPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
-            $userPath = Change-Path $userPath "" ($RuntimeDirs)
+            $userPath = Change-Path $userPath "" $RuntimeDirs
             [Environment]::SetEnvironmentVariable("Path", $userPath, [System.EnvironmentVariableTarget]::User)
         }
         return;
     }
-    
+
     $runtimeInfo = Get-RuntimeAliasOrRuntimeInfo -Version:$VersionOrAlias -Architecture:$Architecture -Runtime:$Runtime -OS:$OS
     $runtimeFullName = $runtimeInfo.RuntimeName
     $runtimeBin = Get-RuntimePath $runtimeFullName
@@ -1562,12 +1569,12 @@ function dnvm-use {
     }
 
     _WriteOut "Adding $runtimeBin to process PATH"
-    Set-Path (Change-Path $env:Path $runtimeBin ($RuntimeDirs))
+    Set-Path (Change-Path $env:Path $runtimeBin $RuntimeDirs)
 
     if ($Persistent) {
         _WriteOut "Adding $runtimeBin to user PATH"
         $userPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
-        $userPath = Change-Path $userPath $runtimeBin ($RuntimeDirs)
+        $userPath = Change-Path $userPath $runtimeBin $RuntimeDirs
         [Environment]::SetEnvironmentVariable("Path", $userPath, [System.EnvironmentVariableTarget]::User)
     }
 }
@@ -1667,7 +1674,7 @@ function dnvm-setup {
     param(
         [switch]$SkipUserEnvironmentInstall)
 
-    $DestinationHome = "$env:USERPROFILE\$DefaultUserDirectoryName"
+    $DestinationHome = [Environment]::ExpandEnvironmentVariables("$DefaultUserHome")
 
     # Install scripts
     $Destination = "$DestinationHome\bin"
@@ -1683,7 +1690,7 @@ function dnvm-setup {
     # Also, clean old user home values if present
     # We'll be removing any existing homes, both
     $PathsToRemove = @(
-        "%USERPROFILE%\$DefaultUserDirectoryName",
+        "$DefaultUserHome",
         [Environment]::ExpandEnvironmentVariables($OldUserHome),
         $DestinationHome,
         $OldUserHome)
@@ -1705,13 +1712,13 @@ function dnvm-setup {
     if(Test-Path "env:\$HomeEnvVar") {
         $processHome = Get-Content "env:\$HomeEnvVar"
     }
-    $processHome = Change-Path $processHome "%USERPROFILE%\$DefaultUserDirectoryName" $PathsToRemove
+    $processHome = Change-Path $processHome "$DefaultUserHome" $PathsToRemove
     Set-Content "env:\$HomeEnvVar" $processHome
 
     if(!$SkipUserEnvironmentInstall) {
         _WriteOut "Adding $DestinationHome to User $HomeEnvVar"
         $userHomeVal = [Environment]::GetEnvironmentVariable($HomeEnvVar, "User")
-        $userHomeVal = Change-Path $userHomeVal "%USERPROFILE%\$DefaultUserDirectoryName" $PathsToRemove
+        $userHomeVal = Change-Path $userHomeVal "$DefaultUserHome" $PathsToRemove
         [Environment]::SetEnvironmentVariable($HomeEnvVar, $userHomeVal, "User")
     }
 }
@@ -1726,19 +1733,19 @@ function Check-Runtimes(){
             }
         }
     }
-    
+
     if (-not $runtimesInstall){
         $title = "Getting started"
         $message = "It looks like you don't have any runtimes installed. Do you want us to install a $RuntimeShortFriendlyName to get you started?"
-    
+
         $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Install the latest runtime for you"
-    
+
         $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Do not install the latest runtime and continue"
-    
+
         $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
-    
+
         $result = $host.ui.PromptForChoice($title, $message, $options, 0)
-        
+
         if($result -eq 0){
             dnvm-upgrade
         }

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -49,9 +49,9 @@ if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $scriptDir "../apps")
 #$env:DNX_FEED = "https://www.myget.org/F/aspnetrelease/api/v2"
 #NOTE: This should be set back to release once we have non windows DNX on that feed.
 $env:DNX_FEED = "https://www.myget.org/F/aspnetvnext/api/v2"
-$TestRuntimeVersion = "1.0.0-beta8-15530"
+$TestRuntimeVersion = "1.0.0-beta8-15618"
 $specificNupkgUrl = "$($env:DNX_FEED)/package/dnx-coreclr-win-x64/$TestRuntimeVersion"
-$specificNupkgHash = "PJpvX+iILTIUA0HxKMPRSU6oO4vkEKe1J/wsors0rIw="
+$specificNupkgHash = "5j65d8HJHUpJ8gHATXJK9wJ6WpEdfz0+48qAAhzND0I="
 $specificNupkgName = "dnx-coreclr-win-x64.$TestRuntimeVersion.nupkg"
 $specificNuPkgFxName = "Asp.Net,Version=v5.0"
 

--- a/test/sh/run-tests.sh
+++ b/test/sh/run-tests.sh
@@ -26,8 +26,8 @@ source $COMMON_HELPERS
 export DNX_FEED
 
 # This is a DNX to use for testing various commands. It doesn't matter what version it is
-[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta8-15530"
-[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='1abc9039fbf10ec3eebc9af216be103ffd1ccb7b'
+[ -z "$_TEST_VERSION" ]     && export _TEST_VERSION="1.0.0-beta8-15618"
+[ -z "$_NUPKG_HASH" ]       && export _NUPKG_HASH='8405a8f2e586627342a78a8c40a3fabbfa2949f9'
 [ -z "$_NUPKG_URL" ]        && export _NUPKG_URL="$DNX_FEED/package/$_DNVM_RUNTIME_PACKAGE_NAME-mono/$_TEST_VERSION"
 [ -z "$_NUPKG_NAME" ]       && export _NUPKG_NAME="$_DNVM_RUNTIME_PACKAGE_NAME-mono.$_TEST_VERSION"
 [ -z "$_NUPKG_FILE" ]       && export _NUPKG_FILE="$TEST_WORK_DIR/${_NUPKG_NAME}.nupkg"


### PR DESCRIPTION
- #422
- previously used `$env:DNX_HOME` or `$env:DNX_GLOBAL_HOME` when undefined
- also ignores `$env:DNX_HOME` values such as ";C:\ProgramData\Microsoft DNX"

nits:
- use constants a bit more consistently
- remove trailing whitespace