### PR TITLE
Pass -Proxy parameter so we can find packages.

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -1366,10 +1366,10 @@ function dnvm-install {
     if (!$IsNuPkg) {
         if ($VersionNuPkgOrAlias -eq "latest") {
             Write-Progress -Activity "Installing runtime" -Status "Determining latest runtime" -Id 1
-            $findPackageResult = Find-Latest -runtimeInfo:$runtimeInfo -Feed:$selectedFeed
+            $findPackageResult = Find-Latest -runtimeInfo:$runtimeInfo -Feed:$selectedFeed -Proxy:$Proxy
         }
         else {
-            $findPackageResult = Find-Package -runtimeInfo:$runtimeInfo -Feed:$selectedFeed
+            $findPackageResult = Find-Package -runtimeInfo:$runtimeInfo -Feed:$selectedFeed -Proxy:$Proxy
         }
         $Version = $findPackageResult.Version
     }


### PR DESCRIPTION
Fix for `dnvm upgrade -Proxy <server>` not working behind a proxy server, by passing parameter on to `Find-Latest` and `Find-Package` methods.

Closes #453.