### PR TITLE
-r, -a and -OS parameters are now case insensitive

### DIFF
--- a/src/dnvm.sh
+++ b/src/dnvm.sh
@@ -38,6 +38,10 @@ __dnvm_has() {
     return $?
 }
 
+__dnvm_to_lower() {
+    echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 if __dnvm_has "unsetopt"; then
     unsetopt nomatch 2>/dev/null
 fi
@@ -550,15 +554,15 @@ dnvm()
                 elif [[ $1 == "-u" || $1 == "-unstable" ]]; then
                     local unstable="-u"
                 elif [[ $1 == "-r" || $1 == "-runtime" ]]; then
-                    local runtime=$2
+                    local runtime=$(__dnvm_to_lower "$2")
                     shift
                 elif [[ $1 == "-OS" ]]; then
-                    local os=$2
+                    local os=$(__dnvm_to_lower "$2")
                     shift
                 elif [[ $1 == "-y" ]]; then
                     local acceptSudo=1
                 elif [[ $1 == "-a" || $1 == "-arch" ]]; then
-                    local arch=$2
+                    local arch=$(__dnvm_to_lower "$2")
                     shift
 
                     if [[ $arch != "x86" && $arch != "x64" ]]; then
@@ -697,13 +701,13 @@ dnvm()
             while [ $# -ne 0 ]
             do
                 if [[ $1 == "-r" || $1 == "-runtime" ]]; then
-                    local runtime=$2
+                    local runtime=$(__dnvm_to_lower "$2")
                     shift
                 elif [[ $1 == "-a" || $1 == "-arch" ]]; then
-                    local architecture=$2
+                    local architecture=$(__dnvm_to_lower "$2")
                     shift
                 elif [[ $1 == "-OS" ]]; then
-                    local os=$2
+                    local os=$(__dnvm_to_lower "$2")
                     shift
                 elif [[ $1 == "-y" ]]; then
                     local acceptSudo=1
@@ -774,10 +778,10 @@ dnvm()
                     if [[ $1 == "-p" || $1 == "-persistent" ]]; then
                         local persistent="true"
                     elif [[ $1 == "-a" || $1 == "-arch" ]]; then
-                        local arch=$2
+                        local arch=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ $1 == "-r" || $1 == "-runtime" ]]; then
-                        local runtime=$2
+                        local runtime=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ $1 == -* ]]; then
                         echo "Invalid option $1" && __dnvm_help && return 1
@@ -791,10 +795,10 @@ dnvm()
                 while [ $# -ne 0 ]
                 do
                     if [[ $1 == "-a" || $1 == "-arch" ]]; then
-                        local arch=$2
+                        local arch=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ $1 == "-r" || $1 == "-runtime" ]]; then
-                        local runtime=$2
+                        local runtime=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ -n $1 ]]; then
                         [[ -n $versionOrAlias ]] && break
@@ -857,7 +861,7 @@ dnvm()
         ;;
 
         "alias" )
-            [[ $# -gt 7 ]] && __dnvm_help && return
+            [[ $# -gt 9 ]] && __dnvm_help && return
 
             [[ ! -e "$_DNVM_ALIAS_DIR/" ]] && mkdir "$_DNVM_ALIAS_DIR/" > /dev/null
 
@@ -902,13 +906,13 @@ dnvm()
             while [ $# -ne 0 ]
                 do
                     if [[ $1 == "-a" || $1 == "-arch" ]]; then
-                        local arch=$2
+                        local arch=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ $1 == "-r" || $1 == "-runtime" ]]; then
-                        local runtime=$2
+                        local runtime=$(__dnvm_to_lower "$2")
                         shift
                     elif [[ $1 == "-OS" ]]; then
-                        local os=$2
+                        local os=$(__dnvm_to_lower "$2")
                         shift
                     fi
                     shift

--- a/test/sh/tests/alias/Alias parameters are case insensitive.sh
+++ b/test/sh/tests/alias/Alias parameters are case insensitive.sh
@@ -1,0 +1,28 @@
+source $COMMON_HELPERS
+source $_DNVM_PATH
+
+DUMMY_RUNTIME="coreclr"
+DUMMY_OS="linux"
+DUMMY_ARCH="x64"
+DUMMY_VERSION="1.0.0-beta7"
+DUMMY_PACKAGE="$_DNVM_RUNTIME_PACKAGE_NAME-$DUMMY_RUNTIME-$DUMMY_OS-$DUMMY_ARCH.$DUMMY_VERSION"
+
+# Create dummy dir for testing if not exists
+if [ ! -d "$DNX_USER_HOME/runtimes/$DUMMY_PACKAGE/bin" ]; then
+    mkdir -p "$DNX_USER_HOME/runtimes/$DUMMY_PACKAGE/bin" > /dev/null
+    CREATED="true"
+fi
+
+# Make the alias
+$_DNVM_COMMAND_NAME alias not_case_sensitive "$DUMMY_VERSION" -r CoreCLR -OS Linux -a X64 || die 'could not create alias'
+
+# Read them
+LIST=$($_DNVM_COMMAND_NAME alias)
+
+# Check the output
+ESCAPED_DUMMY_PACKAGE=$(echo $DUMMY_PACKAGE | sed 's,\.,\\.,g')
+
+echo $LIST | grep -E "not_case_sensitive\s+$ESCAPED_DUMMY_PACKAGE" || die 'list did not include expected alias'
+
+# Cleanup of dummy package
+[[ "$CREATED" == "true" ]] && rm -rf "$DNX_USER_HOME/runtimes/$DUMMY_PACKAGE"


### PR DESCRIPTION
```__dnvm_requested_version_or_alias``` parameters are now case insensitive and dnvm alias can now take 9 parameters.

This fixes #449 and also other issues caused by case sensitivity in commands using ```__dnvm_requested_version_or_alias```

Was this also an issue on Windows? Not currently near a Windows machine so I can't verify.

//cc @muratg @glennc @BrennanConroy 