### PR TITLE
Set machine-wide DNX_HOME in dnvm-setup.

### DIFF
--- a/src/dnvm.ps1
+++ b/src/dnvm.ps1
@@ -1762,7 +1762,8 @@ function dnvm-exec {
 #>
 function dnvm-setup {
     param(
-        [switch]$SkipUserEnvironmentInstall)
+        [switch]$SkipUserEnvironmentInstall,
+        [switch]$SkipSetMachineDnxHome)
 
     $DestinationHome = [Environment]::ExpandEnvironmentVariables("$DefaultUserHome")
 
@@ -1794,6 +1795,13 @@ function dnvm-setup {
         $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
         $userPath = Change-Path $userPath $Destination $PathsToRemove
         [Environment]::SetEnvironmentVariable("PATH", $userPath, "User")
+    }
+
+    if(Is-Elevated) {
+        if (!$SkipSetMachineDnxHome) {
+            _WriteOut "Adding Machine $HomeEnvVar"
+            [Environment]::SetEnvironmentVariable($HomeEnvVar, $Destination, [System.EnvironmentVariableTarget]::Machine)
+        }
     }
 
     # Now clean up the HomeEnvVar if currently set; script installed to default location.


### PR DESCRIPTION
Set machine-wide DNX_HOME environment variable when running dnvm setup on Windows in elevated mode.

#439